### PR TITLE
Fix configuration.yaml parse error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 This file is used to list changes made in each version of the instana-agent
 cookbook.
 
+## 1.0.3
+- Fix configuration.yaml parse error
+
 ## 1.0.2
 - Updated the cookbook to comply with all of our recent feature requests and operational workflows.
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,8 +6,9 @@ maintainer_email 'ops@instana.com'
 license 'Apache-2.0'
 description 'Installs/Configures instana-agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.2'
+version '1.0.3'
 chef_version '>= 12.20.3'
+
 provides 'instana-agent::backend_config'
 provides 'instana-agent::default'
 provides 'instana-agent::mirrors_config'

--- a/templates/default/agent_config.erb
+++ b/templates/default/agent_config.erb
@@ -23,8 +23,8 @@
 # Host
 <% if @tags.length > 0 %>
 com.instana.plugin.host:
-	tags:<% @tags.each do |tag| %>
-		- '<%= tag %>'
+  tags:<% @tags.each do |tag| %>
+    - '<%= tag %>'
 <% end %>
 <% end %>
 


### PR DESCRIPTION
Two tags made a parse error in configuration.yaml.
At least in instana-agent-dynamic-20171221-0259.x86_64

This fix the problem ;)